### PR TITLE
Ws 75 locked split view by default

### DIFF
--- a/src/Pages/PhotosphereViewer.tsx
+++ b/src/Pages/PhotosphereViewer.tsx
@@ -259,8 +259,8 @@ function PhotosphereViewer({
           </Stack>
           <Box sx={{ padding: "0 5px" }}>
             <Button
-              sx={{ height: "35px" }}
-              variant="outlined"
+              sx={{ height: "45px" }}
+              variant={isSplitView ? "contained" : "outlined"}
               onClick={() => {
                 setIsSplitView(!isSplitView);
               }}
@@ -274,7 +274,7 @@ function PhotosphereViewer({
                 <Button
                   variant={lockViews ? "contained" : "outlined"}
                   sx={{
-                    height: "35px",
+                    height: "45px",
                   }}
                   onClick={() => {
                     setLockViews(!lockViews);

--- a/src/Pages/PhotosphereViewer.tsx
+++ b/src/Pages/PhotosphereViewer.tsx
@@ -134,7 +134,7 @@ function PhotosphereViewer({
     <>
       <PhotosphereTutorialEditor /> {}
       <Stack
-        direction="row"
+        direction="column"
         sx={{
           position: "absolute",
           top: "16px",
@@ -143,7 +143,7 @@ function PhotosphereViewer({
           maxWidth: "100%",
           width: "fit-content",
           minWidth: "150px",
-          height: "45px",
+          height: "fit-content",
           padding: "4px",
           margin: "auto",
           backgroundColor: "white",
@@ -155,83 +155,115 @@ function PhotosphereViewer({
         }}
         gap={1}
       >
-        <Box sx={{ padding: "0 5px" }}>
-          <Button
-            sx={{ height: "35px" }}
-            variant="outlined"
-            onClick={() => {
-              setIsSplitView(!isSplitView);
-            }}
-          >
-            <Typography sx={{ fontSize: "14px" }}>Split View</Typography>
-          </Button>
-        </Box>
-        {isSplitView && (
-          <Box>
-            <Button
-              variant={lockViews ? "contained" : "outlined"}
-              sx={{
-                height: "35px",
-              }}
-              onClick={() => {
-                setLockViews(!lockViews);
-              }}
-            >
-              <Typography sx={{ fontSize: "14px" }}>
-                {lockViews ? "Unl" : "L"}ock Views
-              </Typography>
-            </Button>
-          </Box>
-        )}
-        <Box sx={{ padding: "0 5px" }}>
-          <PhotosphereSelector
-            size="small"
-            options={Object.keys(vfe.photospheres)}
-            value={
-              primaryPhotosphere.parentPS
-                ? primaryPhotosphere.parentPS
-                : primaryPhotosphere.id
-            }
-            setValue={(id) => {
-              setPrimaryPhotosphere(vfe.photospheres[id]);
-              setSplitPhotosphere(vfe.photospheres[id]);
-              onChangePS(id);
-            }}
-          />
-        </Box>
-        {primaryPhotosphere.backgroundAudio && (
-          <AudioToggleButton src={primaryPhotosphere.backgroundAudio.path} />
-        )}
-        <FormControlLabel
-          control={
-            <StyledSwitch
-              defaultChecked
-              onChange={() => {
-                setMapStatic(!mapStatic);
-              }}
-            />
-          }
-          label="Map Rotation"
-          componentsProps={{
-            typography: {
-              sx: { fontSize: "14px", padding: 1, width: "60px" },
-            },
+        <Stack
+          direction="row"
+          sx={{
+            maxWidth: "100%",
+            width: "fit-content",
+            minWidth: "150px",
+            height: "48px",
+            padding: "4px",
+            margin: "auto",
+            backgroundColor: "white",
+            borderRadius: "4px",
+            justifyContent: "space-between",
+            alignItems: "center",
           }}
-          sx={{ margin: 0 }}
-        />
-        {isGamified && (
+          gap={1}
+        >
           <Box sx={{ padding: "0 5px" }}>
             <Button
-              sx={{ padding: "0", width: "4px", height: "40px" }}
-              variant="contained"
-              color="primary"
+              sx={{ height: "35px" }}
+              variant="outlined"
               onClick={() => {
-                void AddPoints(10);
+                setIsSplitView(!isSplitView);
               }}
             >
-              Add Points!
+              <Typography sx={{ fontSize: "14px" }}>Split View</Typography>
             </Button>
           </Box>
+
+          <Box sx={{ padding: "0 5px" }}>
+            <PhotosphereSelector
+              size="small"
+              options={Object.keys(vfe.photospheres)}
+              value={
+                primaryPhotosphere.parentPS
+                  ? primaryPhotosphere.parentPS
+                  : primaryPhotosphere.id
+              }
+              setValue={(id) => {
+                setPrimaryPhotosphere(vfe.photospheres[id]);
+                setSplitPhotosphere(vfe.photospheres[id]);
+                onChangePS(id);
+              }}
+            />
+          </Box>
+          {primaryPhotosphere.backgroundAudio && (
+            <AudioToggleButton src={primaryPhotosphere.backgroundAudio.path} />
+          )}
+          <FormControlLabel
+            control={
+              <StyledSwitch
+                defaultChecked
+                onChange={() => {
+                  setMapStatic(!mapStatic);
+                }}
+              />
+            }
+            label="Map Rotation"
+            componentsProps={{
+              typography: {
+                sx: { fontSize: "14px", padding: 1, width: "60px" },
+              },
+            }}
+            sx={{ margin: 0 }}
+          />
+          {isGamified && (
+            <Box sx={{ padding: "0 5px" }}>
+              <Button
+                sx={{ padding: "0", width: "4px", height: "40px" }}
+                variant="contained"
+                color="primary"
+                onClick={() => {
+                  void AddPoints(10);
+                }}
+              >
+                Add Points!
+              </Button>
+            </Box>
+          )}
+        </Stack>
+
+        {isSplitView && (
+          <Stack
+            direction="row"
+            sx={{
+              maxWidth: "100%",
+              width: "fit-content",
+              minWidth: "150px",
+              mb: "5px",
+              justifyContent: "space-between",
+              alignItems: "center",
+            }}
+            gap={1}
+          >
+            <Box>
+              <Button
+                variant={lockViews ? "contained" : "outlined"}
+                sx={{
+                  height: "35px",
+                }}
+                onClick={() => {
+                  setLockViews(!lockViews);
+                }}
+              >
+                <Typography sx={{ fontSize: "14px" }}>
+                  {lockViews ? "Unl" : "L"}ock Views
+                </Typography>
+              </Button>
+            </Box>
+          </Stack>
         )}
       </Stack>
       <Stack
@@ -268,27 +300,6 @@ function PhotosphereViewer({
           />
         )}
       </Stack>
-      <Box
-        sx={{
-          position: "fixed",
-          top: "16px",
-          right: "16px",
-          backgroundColor: "white",
-          borderRadius: "50%",
-          boxShadow: "0 0 4px grey",
-          zIndex: 110, // Ensure it appears above other elements
-        }}
-      >
-        <PhotosphereHotspotSideBar
-          vfe={vfe}
-          currentPS={primaryPhotosphere.id}
-          setValue={(id) => {
-            setPrimaryPhotosphere(vfe.photospheres[id]);
-            setSplitPhotosphere(vfe.photospheres[id]);
-            onChangePS(id);
-          }}
-        />
-      </Box>
       {isGamified && (
         <Stack
           direction="row"
@@ -315,6 +326,27 @@ function PhotosphereViewer({
           <progress value={points ?? 0} max={maxPoints} />{" "}
         </Stack>
       )}
+      <Box
+        sx={{
+          position: "fixed",
+          top: "16px",
+          right: "16px",
+          backgroundColor: "white",
+          borderRadius: "50%",
+          boxShadow: "0 0 4px grey",
+          zIndex: 110, // Ensure it appears above other elements
+        }}
+      >
+        <PhotosphereHotspotSideBar
+          vfe={vfe}
+          currentPS={primaryPhotosphere.id}
+          setValue={(id) => {
+            setPrimaryPhotosphere(vfe.photospheres[id]);
+            setSplitPhotosphere(vfe.photospheres[id]);
+            onChangePS(id);
+          }}
+        />
+      </Box>
     </>
   );
 }

--- a/src/Pages/PhotosphereViewer.tsx
+++ b/src/Pages/PhotosphereViewer.tsx
@@ -19,6 +19,7 @@ import { HotspotUpdate } from "../Pages/PageUtility/VFEConversion";
 import PhotosphereHotspotSideBar from "../PhotosphereFeatures/PhotosphereHotspotSidebar.tsx";
 import PhotospherePlaceholder from "../PhotosphereFeatures/PhotospherePlaceholder";
 import PhotosphereSelector from "../PhotosphereFeatures/PhotosphereSelector";
+import PhotosphereTimelineSelect from "../PhotosphereFeatures/PhotosphereTimelineSelect.tsx";
 import PhotosphereTutorialEditor from "../PhotosphereFeatures/PhotosphereTutorialCreate.tsx";
 import AudioToggleButton from "../buttons/AudioToggleButton";
 
@@ -172,18 +173,6 @@ function PhotosphereViewer({
           gap={1}
         >
           <Box sx={{ padding: "0 5px" }}>
-            <Button
-              sx={{ height: "35px" }}
-              variant="outlined"
-              onClick={() => {
-                setIsSplitView(!isSplitView);
-              }}
-            >
-              <Typography sx={{ fontSize: "14px" }}>Split View</Typography>
-            </Button>
-          </Box>
-
-          <Box sx={{ padding: "0 5px" }}>
             <PhotosphereSelector
               size="small"
               options={Object.keys(vfe.photospheres)}
@@ -235,36 +224,91 @@ function PhotosphereViewer({
           )}
         </Stack>
 
-        {isSplitView && (
+        <Stack
+          direction="row"
+          sx={{
+            maxWidth: "100%",
+            width: "93%",
+            minWidth: "150px",
+            height: "fit-content",
+            justifyContent: "space-between",
+            alignItems: "center",
+          }}
+          gap={1}
+        >
           <Stack
-            direction="row"
+            direction="column"
             sx={{
-              maxWidth: "100%",
+              border: "1px solid gray",
               width: "fit-content",
-              minWidth: "150px",
-              mb: "5px",
-              justifyContent: "space-between",
-              alignItems: "center",
+              height: "fit-content",
+              backgroundColor: "white",
+              borderRadius: "4px",
+              boxShadow: "0 0 4px grey",
+              mt: 0,
+              p: 1,
             }}
-            gap={1}
           >
-            <Box>
-              <Button
-                variant={lockViews ? "contained" : "outlined"}
+            <Typography variant="caption"> Change Time </Typography>
+            <PhotosphereTimelineSelect
+              onSelect={(ps: string) => {
+                console.log(ps);
+                setPrimaryPhotosphere(vfe.photospheres[ps]);
+              }}
+            />
+          </Stack>
+          <Box sx={{ padding: "0 5px" }}>
+            <Button
+              sx={{ height: "35px" }}
+              variant="outlined"
+              onClick={() => {
+                setIsSplitView(!isSplitView);
+              }}
+            >
+              <Typography sx={{ fontSize: "14px" }}>Split View</Typography>
+            </Button>
+          </Box>
+          {isSplitView && (
+            <>
+              <Box>
+                <Button
+                  variant={lockViews ? "contained" : "outlined"}
+                  sx={{
+                    height: "35px",
+                  }}
+                  onClick={() => {
+                    setLockViews(!lockViews);
+                  }}
+                >
+                  <Typography sx={{ fontSize: "14px" }}>
+                    {lockViews ? "Unl" : "L"}ock Views
+                  </Typography>
+                </Button>
+              </Box>
+              <Stack
+                direction="column"
                 sx={{
-                  height: "35px",
-                }}
-                onClick={() => {
-                  setLockViews(!lockViews);
+                  border: "1px solid gray",
+                  width: "fit-content",
+                  height: "fit-content",
+                  backgroundColor: "white",
+                  borderRadius: "4px",
+                  boxShadow: "0 0 4px grey",
+                  mt: 0,
+                  p: 1,
                 }}
               >
-                <Typography sx={{ fontSize: "14px" }}>
-                  {lockViews ? "Unl" : "L"}ock Views
-                </Typography>
-              </Button>
-            </Box>
-          </Stack>
-        )}
+                <Typography variant="caption"> Change Time </Typography>
+                <PhotosphereTimelineSelect
+                  onSelect={(ps: string) => {
+                    console.log(ps);
+                    setSplitPhotosphere(vfe.photospheres[ps]);
+                  }}
+                />
+              </Stack>
+            </>
+          )}
+        </Stack>
       </Stack>
       <Stack
         direction="row"

--- a/src/Pages/PhotosphereViewer.tsx
+++ b/src/Pages/PhotosphereViewer.tsx
@@ -114,7 +114,7 @@ function PhotosphereViewer({
   const [mapStatic, setMapStatic] = useState(false);
 
   const [isSplitView, setIsSplitView] = useState(false);
-  const [lockViews, setLockViews] = useState(false);
+  const [lockViews, setLockViews] = useState(true);
 
   const [points, AddPoints] = usePoints();
 

--- a/src/PhotosphereFeatures/PhotospherePlaceholder.tsx
+++ b/src/PhotosphereFeatures/PhotospherePlaceholder.tsx
@@ -362,32 +362,6 @@ function PhotospherePlaceholder({
           overflow: "hidden",
         }}
       >
-        <Stack
-          direction="column"
-          sx={{
-            position: "absolute",
-            height: "60px",
-            top: 100,
-            left: 8,
-            border: "1px solid gray",
-            p: 4,
-            pt: 0,
-            zIndex: 100,
-            backgroundColor: "white",
-            borderRadius: "4px",
-            boxShadow: "0 0 4px grey",
-            mt: 0,
-          }}
-        >
-          <Typography> Change Time </Typography>
-          <PhotosphereTimelineSelect
-            onSelect={(ps: string) => {
-              console.log(ps);
-              setCurrentPhotosphere(vfe.photospheres[ps]);
-            }}
-          />
-        </Stack>
-
         <ReactPhotoSphereViewer
           key={mapStatic ? "static" : "dynamic"}
           onReady={handleReady}

--- a/src/PhotosphereFeatures/PhotospherePlaceholder.tsx
+++ b/src/PhotosphereFeatures/PhotospherePlaceholder.tsx
@@ -15,7 +15,7 @@ import {
   VirtualTourPluginConfig,
 } from "react-photo-sphere-viewer";
 
-import { Box, Stack, Typography, alpha } from "@mui/material";
+import { Box, alpha } from "@mui/material";
 import { common } from "@mui/material/colors";
 
 import { useVisitedState } from "../Hooks/HandleVisit";
@@ -29,7 +29,6 @@ import {
 import PopOver from "../Pages/PageUtility/PopOver";
 import { ViewerProps } from "../Pages/PhotosphereViewer";
 import { LinkArrowIconHTML } from "../UI/LinkArrowIcon";
-import PhotosphereTimelineSelect from "./PhotosphereTimelineSelect";
 
 /** Convert sizes from numbers to strings ending in "px" */
 function sizeToStr(val: number): string {

--- a/src/PhotosphereFeatures/PhotosphereTimelineSelect.tsx
+++ b/src/PhotosphereFeatures/PhotosphereTimelineSelect.tsx
@@ -32,6 +32,7 @@ function PhotosphereTimelineSelect({
     <Select
       sx={{
         width: "fit-content",
+        maxWidth: "110px",
       }}
       value={selected}
       onChange={handleChange}
@@ -49,7 +50,7 @@ function PhotosphereTimelineSelect({
           time_string = time;
         }
         return (
-          <MenuItem key={time} value={ps} sx={{ fontSize: "small" }}>
+          <MenuItem key={time} value={ps} sx={{ overflow: "hidden" }}>
             {time_string}
           </MenuItem>
         );

--- a/src/PhotosphereFeatures/PhotosphereTimelineSelect.tsx
+++ b/src/PhotosphereFeatures/PhotosphereTimelineSelect.tsx
@@ -30,19 +30,12 @@ function PhotosphereTimelineSelect({
   }
   return (
     <Select
-      MenuProps={{
-        disablePortal: true,
-        PaperProps: {
-          sx: {
-            position: "absolute",
-            height: "fit-content",
-            zIndex: 100,
-            p: 0,
-          },
-        },
+      sx={{
+        width: "fit-content",
       }}
       value={selected}
       onChange={handleChange}
+      size="small"
     >
       {Object.entries(timeline).map(([time, ps]) => {
         let time_string;
@@ -56,7 +49,7 @@ function PhotosphereTimelineSelect({
           time_string = time;
         }
         return (
-          <MenuItem key={time} value={ps}>
+          <MenuItem key={time} value={ps} sx={{ fontSize: "small" }}>
             {time_string}
           </MenuItem>
         );


### PR DESCRIPTION
## Description
Updated the feature bar in the Photosphere Viewer to better layout the new split view features. Made the lock views lock by default when a user first goes into split view.
## Changes
`PhotosphereViewer`: Moved around some components to make the feature bar more concise. All split view features are now in a second row to be persistent and cleaner for the user. 

`PhotospherePlaceholder`: Moved the timeline selector component to the parent component of `PhotosphereViewer` to allow the feature bar to be concise and user friendly.

`TimelineSelector`: Updated styling so that the new feature bar can incorporate the selector seamlessly.

## Testing
Tested on a firefox based browser to make sure the bar didn't break. If anything to hard to read please let me know. 