### PR TITLE
Add logic to have map rotation off by default

### DIFF
--- a/src/Pages/PhotosphereViewer.tsx
+++ b/src/Pages/PhotosphereViewer.tsx
@@ -194,7 +194,7 @@ function PhotosphereViewer({
           <FormControlLabel
             control={
               <StyledSwitch
-                defaultChecked
+                checked={mapRotationEnabled}
                 onChange={() => {
                   setMapRotationEnabled(!mapRotationEnabled);
                 }}

--- a/src/Pages/PhotosphereViewer.tsx
+++ b/src/Pages/PhotosphereViewer.tsx
@@ -110,7 +110,7 @@ function PhotosphereViewer({
   const [splitPhotosphere, setSplitPhotosphere] = React.useState<Photosphere>(
     vfe.photospheres[currentPS],
   );
-  const [mapStatic, setMapStatic] = useState(false);
+  const [mapRotationEnabled, setMapRotationEnabled] = useState(false);
 
   const [isSplitView, setIsSplitView] = useState(false);
   const [lockViews, setLockViews] = useState(false);
@@ -205,9 +205,9 @@ function PhotosphereViewer({
         <FormControlLabel
           control={
             <StyledSwitch
-              defaultChecked
+              checked={mapRotationEnabled}
               onChange={() => {
-                setMapStatic(!mapStatic);
+                setMapRotationEnabled(!mapRotationEnabled);
               }}
             />
           }
@@ -256,14 +256,14 @@ function PhotosphereViewer({
         <PhotospherePlaceholder
           viewerProps={viewerProps}
           isPrimary={true}
-          mapStatic={mapStatic}
+          mapStatic={!mapRotationEnabled}
           lockViews={lockViews}
         />
         {isSplitView && (
           <PhotospherePlaceholder
             viewerProps={viewerProps}
             isPrimary={false}
-            mapStatic={mapStatic}
+            mapStatic={!mapRotationEnabled}
             lockViews={lockViews}
           />
         )}

--- a/src/PhotosphereFeatures/PhotospherePlaceholder.tsx
+++ b/src/PhotosphereFeatures/PhotospherePlaceholder.tsx
@@ -396,7 +396,7 @@ function PhotospherePlaceholder({
           plugins={plugins}
           height={"100vh"}
           width={"100%"}
-          navbar={["autorotate", "zoom", "caption", "download", "fullscreen"]}
+          navbar={["zoom", "caption", "download", "fullscreen"]}
         />
       </Box>
     </>


### PR DESCRIPTION
Changed name of map rotation variable for readability and kept rotation off by default. 

This is one of the changes requested by Rick last term and it makes it easier for new users to navigate the tools. 

Tested the change on Chrome to ensure that upon reload, map rotation is off. 