### PR TITLE
Add Default Scene Feature

### DIFF
--- a/src/Pages/CreateVFE.tsx
+++ b/src/Pages/CreateVFE.tsx
@@ -1,4 +1,5 @@
 import { MuiFileInput } from "mui-file-input";
+import PhotosphereSelector from "../PhotosphereFeatures/PhotosphereSelector.tsx";
 import { useState } from "react";
 
 import AttachFileIcon from "@mui/icons-material/AttachFile";
@@ -9,6 +10,7 @@ import PhotosphereTutorialCreate from "../PhotosphereFeatures/PhotosphereTutoria
 import Header, { HeaderProps } from "../UI/Header.tsx";
 import { alertMUI } from "../UI/StyledDialogWrapper.tsx";
 import {
+  Photosphere,
   NavMap,
   VFE,
   calculateImageDimensions,
@@ -41,6 +43,8 @@ function CreateVFEForm({ onCreateVFE, header, onClose }: CreateVFEFormProps) {
   // Base states
   const [vfeName, setVFEName] = useState("");
   const [photosphereName, setPhotosphereName] = useState(""); // State for Photosphere Name
+  const [photospheres, setPhotospheres] = useState<Record<string, Photosphere>>({});
+  const [defaultPhotosphereID, setDefaultPhotosphereID] = useState("");
   const [panoImage, setPanoImage] = useState("");
   const [panoFile, setPanoFile] = useState<File | null>(null); // needed for MuiFileInput
   const [audio, setAudio] = useState("");
@@ -56,32 +60,26 @@ function CreateVFEForm({ onCreateVFE, header, onClose }: CreateVFEFormProps) {
   // Error Handling: Ensure the data is not empty
 
   async function handleCreateVFE() {
-    if (vfeName.trim() === "" || photosphereName.trim() === "" || !panoImage) {
+    if (
+      vfeName.trim() === "" ||
+      Object.keys(photospheres).length === 0 ||
+      !defaultPhotosphereID
+    ) {
       await alertMUI(
-        "Please, provide a VFE name, Photosphere name, and an image.",
+        "Please provide a VFE name, add at least one scene, and choose a default starting point.",
       );
       return;
     }
-    // Input data into new VFE
+  
     const data: VFE = {
       name: vfeName,
-      defaultPhotosphereID: photosphereName,
-      photospheres: {
-        [photosphereName]: {
-          id: photosphereName,
-          src: { tag: "Runtime", id: newID(), path: panoImage },
-          center: photospherePosition ? photospherePosition : undefined,
-          hotspots: {},
-          backgroundAudio: audio
-            ? { tag: "Runtime", id: newID(), path: audio }
-            : undefined,
-          timeline: {},
-        },
-      },
+      defaultPhotosphereID,
+      photospheres,
       map: navMap,
     };
+  
     onCreateVFE(data);
-  }
+  }  
 
   function handleImageChange(file: File | null) {
     if (file) {
@@ -124,6 +122,56 @@ function CreateVFEForm({ onCreateVFE, header, onClose }: CreateVFEFormProps) {
       <PhotosphereTutorialCreate /> {}
       <Stack sx={{ width: 450, margin: "auto", paddingTop: 10 }} gap={3}>
         <Typography variant="h4">Create a New VFE</Typography>
+        <Button
+          variant="outlined"
+          onClick={async () => {
+            if (!photosphereName || !panoImage) {
+              await alertMUI("Please provide a scene name and panorama image.");
+              return;
+            }
+
+            const newPS: Photosphere = {
+              id: photosphereName,
+              src: { tag: "Runtime", id: newID(), path: panoImage },
+              center: photospherePosition ?? undefined,
+              hotspots: {},
+              backgroundAudio: audio
+                ? { tag: "Runtime", id: newID(), path: audio }
+                : undefined,
+              timeline: {},
+            };
+
+            setPhotospheres((prev) => ({ ...prev, [photosphereName]: newPS }));
+
+            if (!defaultPhotosphereID) {
+              setDefaultPhotosphereID(photosphereName);
+            }
+
+            // Clear inputs
+            setPhotosphereName("");
+            setPanoImage("");
+            setPanoFile(null);
+            setAudio("");
+            setAudioFile(null);
+          }}
+        >
+          Add Scene
+        </Button>
+
+        {Object.keys(photospheres).length > 0 && (
+        <Stack direction="row" alignItems="center" gap={1}>
+          <Typography>Default Starting Scene:</Typography>
+          <PhotosphereSelector
+            size="small"
+            options={Object.keys(photospheres)}
+            value={defaultPhotosphereID}
+            setValue={setDefaultPhotosphereID}
+            defaultPhotosphereID={defaultPhotosphereID}
+          />
+        </Stack>
+      )}
+
+
         <Stack direction="row" gap={1}>
           <TextField
             required

--- a/src/Pages/PhotosphereEditor.tsx
+++ b/src/Pages/PhotosphereEditor.tsx
@@ -275,15 +275,20 @@ function PhotosphereEditor({
           photosphereOptions={availablePhotosphereOptions}
         />
       );
-    if (showChangePhotosphere) {
-      return (
-        <ChangePhotosphere
-          ps={vfe.photospheres[currentPS]}
-          onCancel={resetStates}
-          onChangePhotosphere={handleChangePhotosphere}
-        />
-      );
-    }
+      if (showChangePhotosphere) {
+        return (
+          <ChangePhotosphere
+            ps={vfe.photospheres[currentPS]}
+            onCancel={resetStates}
+            onChangePhotosphere={handleChangePhotosphere}
+            defaultPhotosphereID={vfe.defaultPhotosphereID}
+            onChangeDefault={(newID) => {
+              onUpdateVFE({ ...vfe, defaultPhotosphereID: newID });
+            }}
+          />
+        );
+      }
+      
     if (showRemovePhotosphere)
       return (
         <RemovePhotosphere

--- a/src/PhotosphereFeatures/PhotosphereSelector.tsx
+++ b/src/PhotosphereFeatures/PhotosphereSelector.tsx
@@ -9,6 +9,7 @@ export interface PhotosphereSelectorProps {
   value: string;
   setValue: (value: string) => void;
   size?: "medium" | "small";
+  defaultPhotosphereID?: string;
 }
 
 function PhotosphereSelector({
@@ -16,6 +17,7 @@ function PhotosphereSelector({
   value,
   setValue,
   size = "medium",
+  defaultPhotosphereID
 }: PhotosphereSelectorProps) {
   // Helper function to reduce ternary/undefined repetition.
   function ifSmall<T, D>(value: T, defaultValue?: D): T | D | undefined {
@@ -25,7 +27,13 @@ function PhotosphereSelector({
   const [runTutorial, setRunTutorial] = useState(false);
   const [stepIndex, setStepIndex] = useState(0);
 
-  options = options.filter((id) => !id.startsWith("CHILD_"));
+  const displayOptions = options
+  .filter((id) => !id.startsWith("CHILD_"))
+  .map((id) => ({
+    label: id === defaultPhotosphereID ? `${id} (default)` : id,
+    raw: id,
+  }));
+
 
   return (
     <FormControl size={size}>
@@ -55,15 +63,11 @@ function PhotosphereSelector({
           { minWidth: "150px" },
         )}
       >
-        {options.map((option) => (
-          <MenuItem
-            key={option}
-            value={option}
-            sx={ifSmall({ fontSize: "13px" })}
-          >
-            {option}
-          </MenuItem>
-        ))}
+      {displayOptions.map(({ raw, label }) => (
+        <MenuItem key={raw} value={raw} sx={ifSmall({ fontSize: "13px" })}>
+        {label}
+        </MenuItem>
+      ))}
       </Select>
     </FormControl>
   );

--- a/src/buttons/ChangePhotosphere.tsx
+++ b/src/buttons/ChangePhotosphere.tsx
@@ -10,6 +10,8 @@ import {
   DialogTitle,
   Stack,
   TextField,
+  FormControlLabel, 
+  Checkbox
 } from "@mui/material";
 
 import { Photosphere } from "../Pages/PageUtility/DataStructures";
@@ -19,16 +21,21 @@ interface ChangePhotosphereProps {
   onChangePhotosphere: (name: string, background: string) => void;
   onCancel: () => void;
   ps: Photosphere;
+  defaultPhotosphereID: string;
+  onChangeDefault: (newDefaultID: string) => void;
 }
 
 function ChangePhotosphere({
   onChangePhotosphere,
   onCancel,
   ps,
+  defaultPhotosphereID,
+  onChangeDefault,
 }: ChangePhotosphereProps) {
   const [name, setName] = useState(ps.id);
   const [background, setBackground] = useState(ps.src.path);
   const [backgroundFile, setBackgroundFile] = useState<File | null>(null);
+  const [isDefault, setIsDefault] = useState(ps.id === defaultPhotosphereID);
 
   function handleBackgroundChange(file: File | null) {
     if (file) {
@@ -43,6 +50,9 @@ function ChangePhotosphere({
       return;
     }
     onChangePhotosphere(name, background);
+    if (isDefault && ps.id !== defaultPhotosphereID) {
+      onChangeDefault(ps.id); 
+    }
   }
 
   return (
@@ -65,6 +75,15 @@ function ChangePhotosphere({
             InputProps={{
               startAdornment: <AttachFileIcon />,
             }}
+          />
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={isDefault}
+                onChange={(e) => setIsDefault(e.target.checked)}
+              />
+            }
+            label="Set as default scene"
           />
         </Stack>
       </DialogContent>

--- a/src/buttons/RemovePhotosphere.tsx
+++ b/src/buttons/RemovePhotosphere.tsx
@@ -38,9 +38,17 @@ function RemovePhotosphere({
     options: options,
     value: selectedPhotosphere,
     setValue: setSelectedPhotosphere,
+    defaultPhotosphereID: vfe.defaultPhotosphereID,
   };
 
   async function handleRemovePhotosphere() {
+    if (selectedPhotosphere === vfe.defaultPhotosphereID) {
+      await alertMUI(
+        `"${selectedPhotosphere}" is the default scene and cannot be removed.\n`
+      );
+      return;
+    }
+    
     if (!selectedPhotosphere) {
       await alertMUI("Please select a photosphere to remove.");
       return;


### PR DESCRIPTION
This PR implements the ability to select a default starting photosphere for each VFE. The selected default scene is used to launch the viewer consistently and helps with structured exploration. 

Features added: 
- Default scene selection on Create VFE workflow. When creating a VFE, the first scene is automatically marked as the default but a dropdown appears after at least one scene is added to let users change the default
- Default scene editing support with a checkbox. The checkbox in the Edit Photosphere mode allows for setting a scene as the new default. This automatically updates defaultPhotosphereID in the VFE
- Deletion safeguard, preventing deletion of the default photosphere
- The PhotosphereSelector now appends " (default) " next to the current default scene

Testing
- Verified that the selected default is saved correctly 
- Confirmed viewer launches into default scene
- Attempts to remove the default scene shows a warning to prevent deletion
