### PR TITLE
Ws 59 cleaner hotspot icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "jszip": "^3.10.1",
         "localforage": "^1.10.0",
         "mui-file-input": "^4.0.4",
+        "phosphor-react": "^1.4.1",
         "react": "^18.2.0",
         "react-colorful": "^5.6.1",
         "react-confirm": "^0.3.0-7",
@@ -5981,6 +5982,18 @@
       "optionalDependencies": {
         "canvas": "^3.0.0-rc2",
         "path2d": "^0.2.1"
+      }
+    },
+    "node_modules/phosphor-react": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/phosphor-react/-/phosphor-react-1.4.1.tgz",
+      "integrity": "sha512-gO5j7U0xZrdglTAYDYPACU4xDOFBTJmptrrB/GeR+tHhCZF3nUMyGmV/0hnloKjuTrOmpSFlbfOY78H39rgjUQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16"
       }
     },
     "node_modules/photo-sphere-viewer-lensflare-plugin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@mui/icons-material": "^5.15.14",
         "@mui/material": "^5.15.14",
         "@mui/x-date-pickers": "^8.3.0",
+        "@phosphor-icons/react": "^2.1.8",
         "dayjs": "^1.11.13",
         "file-saver": "^2.0.5",
         "jszip": "^3.10.1",
@@ -1509,6 +1510,19 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@phosphor-icons/react": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.8.tgz",
+      "integrity": "sha512-RxJlAkErO+t50DsY82ga9RGOULK6Jux0MdmXqvDjtOzG3PYQFz6rjdUU2q06lPMMbJTT+d+qurKYmF7i2Uv74A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8",
+        "react-dom": ">= 16.8"
       }
     },
     "node_modules/@photo-sphere-viewer/autorotate-plugin": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@mui/icons-material": "^5.15.14",
     "@mui/material": "^5.15.14",
     "@mui/x-date-pickers": "^8.3.0",
+    "@phosphor-icons/react": "^2.1.8",
     "dayjs": "^1.11.13",
     "file-saver": "^2.0.5",
     "jszip": "^3.10.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "jszip": "^3.10.1",
     "localforage": "^1.10.0",
     "mui-file-input": "^4.0.4",
+    "phosphor-react": "^1.4.1",
     "react": "^18.2.0",
     "react-colorful": "^5.6.1",
     "react-confirm": "^0.3.0-7",

--- a/src/Pages/CreateVFE.tsx
+++ b/src/Pages/CreateVFE.tsx
@@ -52,6 +52,7 @@ function CreateVFEForm({ onCreateVFE, header, onClose }: CreateVFEFormProps) {
     x: number;
     y: number;
   } | null>(null);
+  const [pinColor, setPinColor] = useState("1976d2"); 
 
   // Error Handling: Ensure the data is not empty
 
@@ -76,6 +77,7 @@ function CreateVFEForm({ onCreateVFE, header, onClose }: CreateVFEFormProps) {
             ? { tag: "Runtime", id: newID(), path: audio }
             : undefined,
           timeline: {},
+          color: pinColor, 
         },
       },
       map: navMap,
@@ -144,6 +146,14 @@ function CreateVFEForm({ onCreateVFE, header, onClose }: CreateVFEFormProps) {
             }}
           />
         </Stack>
+        <TextField
+          label="Pin Color"
+          type="color"
+          value={pinColor}
+          onChange={(e) => setPinColor(e.target.value)}
+          InputLabelProps={{ shrink: true }}
+          fullWidth
+        />
         <MuiFileInput
           required
           placeholder="Upload a Panorama *"

--- a/src/Pages/HotspotEditor.tsx
+++ b/src/Pages/HotspotEditor.tsx
@@ -441,7 +441,6 @@ function HotspotEditor({
       setEdited(true);
     }
   }
-  console.log("[HotspotEditor] previewColor:", previewColor);
 
   return (
     <Stack gap={2} width="300px" height="100%">
@@ -652,7 +651,6 @@ function HotspotEditor({
                 previewColor
               );
             }
-            console.log("[HotspotEditor] saving with color:", previewColor);
 
           }}
         >
@@ -678,7 +676,6 @@ function HotspotEditor({
                 previewColor
               );
             }
-            console.log("[HotspotEditor] saving with color:", previewColor);
 
           }}
         >

--- a/src/Pages/HotspotEditor.tsx
+++ b/src/Pages/HotspotEditor.tsx
@@ -23,9 +23,13 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
+  FormControl,
   IconButton,
+  InputLabel,
   Link,
+  MenuItem,
   Popover,
+  Select,
   Stack,
   TextField,
   Tooltip,
@@ -366,6 +370,8 @@ export interface HotspotEditorProps {
   ) => void;
   openNestedHotspot: (toOpen: Hotspot2D) => void;
   photosphereOptions: string[];
+  previewColor: string;
+  setPreviewColor: (color: string) => void;
 }
 
 function HotspotEditor({
@@ -377,24 +383,25 @@ function HotspotEditor({
   setPreviewData,
   previewIcon,
   setPreviewIcon,
-
   resetHotspot,
   deleteHotspot,
   updateHotspot,
   openNestedHotspot,
   photosphereOptions,
+  previewColor, 
+  setPreviewColor,
 }: HotspotEditorProps) {
   const [isCustomIcon] = useState(false);
   const [customIconFile, setCustomIconFile] = useState<File | null>(null);
-  const [color] = useState("#1976d2");
+  const color = previewColor;
+  const setColor = setPreviewColor;
   const [hotspotsCollapsed, setHotspotsCollapsed] = useState(false);
-
   const [colorAnchor, setColorAnchor] = useState<HTMLElement | null>(null);
   const [colorHotspot, setColorHotspot] = useState<Hotspot2D | null>(null);
   const [locationHotspot, setLocationHotspot] = useState<Hotspot2D | null>(
     null,
   );
-
+  
   const nestedHotspotLength =
     previewData?.tag === "Image"
       ? Object.values(previewData.hotspots).length
@@ -434,6 +441,7 @@ function HotspotEditor({
       setEdited(true);
     }
   }
+  console.log("[HotspotEditor] previewColor:", previewColor);
 
   return (
     <Stack gap={2} width="300px" height="100%">
@@ -457,6 +465,44 @@ function HotspotEditor({
         setHotspotData={updateData}
         photosphereOptions={photosphereOptions}
       />
+      <FormControl fullWidth>
+        <InputLabel id="pin-type-label">Pin Type</InputLabel>
+        <Select
+          labelId="pin-type-label"
+          label="Pin Type"
+          value={previewIcon?.path || ""}
+          onChange={(e) => {
+            const path = e.target.value;
+            setPreviewIcon?.({
+              tag: "Runtime",
+              id: newID(),
+              path,
+            });
+            setEdited(true);
+          }}
+        >
+          <MenuItem value="/pin-blue.png">Blue Pin</MenuItem>
+          <MenuItem value="/pin-red.png">Red Pin</MenuItem>
+          <MenuItem value="MapPin">Map Pin</MenuItem>
+          <MenuItem value="PushPinSimple">Push Pin Simple</MenuItem>
+          <MenuItem value="MapTrifold">Map Trifold</MenuItem>
+        </Select>
+      </FormControl>
+
+    {previewIcon?.path !== "/pin-blue.png" && previewIcon?.path !== "/pin-red.png" && (
+      <TextField
+        label="Pin Color"
+        type="color"
+        value={color}
+        onChange={(e) => {
+          setColor(e.target.value);
+          setEdited(true);
+        }}
+        InputLabelProps={{ shrink: true }}
+        fullWidth
+      />
+    )}
+
 
     {isCustomIcon && (
       <MuiFileInput
@@ -599,15 +645,15 @@ function HotspotEditor({
             if (previewData !== null) {
               sessionStorage.setItem("lastEditedHotspotFlag", "1");
 
-              const shouldHaveColor = !isCustomIcon && previewIcon?.path !== "/pin-blue.png" && previewIcon?.path !== "/pin-red.png";
-
               updateHotspot(
                 previewTooltip,
                 previewData,
                 previewIcon ?? undefined,
-                shouldHaveColor ? color : undefined
+                previewColor
               );
             }
+            console.log("[HotspotEditor] saving with color:", previewColor);
+
           }}
         >
           Save
@@ -629,8 +675,11 @@ function HotspotEditor({
                 previewTooltip,
                 previewData,
                 previewIcon ?? undefined,
+                previewColor
               );
             }
+            console.log("[HotspotEditor] saving with color:", previewColor);
+
           }}
         >
           Save and Exit

--- a/src/Pages/HotspotEditor.tsx
+++ b/src/Pages/HotspotEditor.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useState } from "react";
+import { forwardRef, useState} from "react";
 import { HexColorPicker } from "react-colorful";
 import "react-h5-audio-player/lib/styles.css";
 
@@ -43,7 +43,8 @@ import {
   photosphereLinkTooltip,
 } from "./PageUtility/DataStructures";
 import { LinkArrowIcon } from "../UI/LinkArrowIcon";
-import { HotspotDataEditor, HotspotIconEditor } from "../buttons/AddHotspot";
+import { HotspotDataEditor} from "../buttons/AddHotspot";
+import { MuiFileInput } from "mui-file-input";
 
 export interface HotspotIconProps {
   hotspotData: HotspotData;
@@ -361,6 +362,7 @@ export interface HotspotEditorProps {
     newTooltip: string,
     newData: HotspotData,
     newIcon?: Asset,
+    newColor?: string,
   ) => void;
   openNestedHotspot: (toOpen: Hotspot2D) => void;
   photosphereOptions: string[];
@@ -382,6 +384,9 @@ function HotspotEditor({
   openNestedHotspot,
   photosphereOptions,
 }: HotspotEditorProps) {
+  const [isCustomIcon] = useState(false);
+  const [customIconFile, setCustomIconFile] = useState<File | null>(null);
+  const [color] = useState("#1976d2");
   const [hotspotsCollapsed, setHotspotsCollapsed] = useState(false);
 
   const [colorAnchor, setColorAnchor] = useState<HTMLElement | null>(null);
@@ -453,15 +458,26 @@ function HotspotEditor({
         photosphereOptions={photosphereOptions}
       />
 
-      {setPreviewIcon && (
-        <HotspotIconEditor
-          iconAsset={previewIcon}
-          setIconAsset={(icon) => {
-            setPreviewIcon(icon);
+    {isCustomIcon && (
+      <MuiFileInput
+        label="Upload Custom Icon*"
+        value={customIconFile}
+        onChange={(file) => {
+          setCustomIconFile(file);
+          if (file) {
+            setPreviewIcon?.({
+              tag: "Runtime",
+              id: newID(),
+              path: URL.createObjectURL(file),
+            });
             setEdited(true);
-          }}
-        />
-      )}
+          }
+        }}
+        inputProps={{ accept: "image/*" }}
+        fullWidth
+      />
+    )}
+
 
       {previewData?.tag === "Image" && (
         <>
@@ -579,10 +595,13 @@ function HotspotEditor({
           sx={{ width: "50%" }}
           onClick={() => {
             if (previewData !== null) {
+              const shouldHaveColor = !isCustomIcon && previewIcon?.path !== "/pin-blue.png" && previewIcon?.path !== "/pin-red.png";
+
               updateHotspot(
                 previewTooltip,
                 previewData,
                 previewIcon ?? undefined,
+                shouldHaveColor ? color : undefined
               );
             }
           }}

--- a/src/Pages/PageUtility/DataStructures.ts
+++ b/src/Pages/PageUtility/DataStructures.ts
@@ -73,6 +73,7 @@ export interface Photosphere {
   backgroundAudio?: Asset;
   timeline: Record<string, string>;
   parentPS?: string;
+  color?: string;
 }
 
 // Hotspot2D: a clickable resource that is inside a 2D image (x, y)
@@ -94,6 +95,7 @@ export interface Hotspot3D {
   level: number;
   icon: Asset;
   data: HotspotData;
+  color?: string;
 }
 
 // HotspotData: types of media resources for a hotspot within a photosphere

--- a/src/Pages/PageUtility/PopOver.tsx
+++ b/src/Pages/PageUtility/PopOver.tsx
@@ -281,7 +281,6 @@ function PopOver({
   }
 
   function updateHotspot(tooltip: string, data: HotspotData, icon?: Asset, color?: string) {
-    console.log("[PopOver] Calling onUpdateHotspot with color:", color);
     onUpdateHotspot?.(hotspotPath, { tooltip, data, icon, color});
   }
 

--- a/src/Pages/PageUtility/PopOver.tsx
+++ b/src/Pages/PageUtility/PopOver.tsx
@@ -1,5 +1,5 @@
 import DocViewer, { DocViewerRenderers } from "@cyntler/react-doc-viewer";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import AudioPlayer from "react-h5-audio-player";
 import "react-h5-audio-player/lib/styles.css";
 import ReactPlayer from "react-player";
@@ -228,6 +228,13 @@ function PopOver({
       ? setPreviewIcon
       : undefined;
 
+  const [previewColor, setPreviewColor] = useState(hotspot.color ?? "#1976d2");
+  useEffect(() => {
+    if ("color" in hotspot && typeof hotspot.color === "string") {
+      setPreviewColor(hotspot.color);
+    }
+  }, [hotspot]);  
+
   const availablePhotosphereOptions =
     hotspot.data.tag === "PhotosphereLink"
       ? [hotspot.data.photosphereID, ...photosphereOptions]
@@ -273,8 +280,9 @@ function PopOver({
     onUpdateHotspot?.(hotspotPath, null);
   }
 
-  function updateHotspot(tooltip: string, data: HotspotData, icon?: Asset) {
-    onUpdateHotspot?.(hotspotPath, { tooltip, data, icon });
+  function updateHotspot(tooltip: string, data: HotspotData, icon?: Asset, color?: string) {
+    console.log("[PopOver] Calling onUpdateHotspot with color:", color);
+    onUpdateHotspot?.(hotspotPath, { tooltip, data, icon, color});
   }
 
   function openNestedHotspot(hotspot2D: Hotspot2D) {
@@ -306,7 +314,7 @@ function PopOver({
             {previewData && (
               <HotspotIcon
                 hotspotData={previewData}
-                color={"color" in hotspot ? hotspot.color : undefined}
+                color={previewColor}
                 icon={previewIcon ?? undefined}
               />
             )}
@@ -380,6 +388,8 @@ function PopOver({
                 updateHotspot={updateHotspot}
                 openNestedHotspot={openNestedHotspot}
                 photosphereOptions={availablePhotosphereOptions} // Pass down the new props
+                previewColor={previewColor}
+                setPreviewColor={setPreviewColor}
               />
             </Box>
           )}

--- a/src/Pages/PageUtility/VFEConversion.ts
+++ b/src/Pages/PageUtility/VFEConversion.ts
@@ -151,6 +151,7 @@ export interface HotspotUpdate {
   tooltip?: string;
   data?: HotspotData;
   icon?: Asset;
+  color?: string;
 }
 
 export function updatePhotosphereHotspot(
@@ -178,6 +179,8 @@ function updateHotspot<H extends Hotspot3D | Hotspot2D>(
   hotspotPath: string[],
   update: HotspotUpdate | null,
 ): H | null {
+  console.log("[VFEConversion] updateHotspot called with update:", update);
+
   // Found the hotspot that is being searched for.
   if (hotspotPath.length === 1 && hotspotPath[0] === hotspot.id) {
     if (update === null) {
@@ -194,6 +197,12 @@ function updateHotspot<H extends Hotspot3D | Hotspot2D>(
     if (update.icon && "icon" in result) {
       result.icon = update.icon;
     }
+    if (update.color) {
+      (result as any).color = update.color;
+      console.log("[VFEConversion] Updated hotspot color:", (result as any).color);
+    }
+    console.log("[VFEConversion] updated hotspot result:", result);
+
     return result;
   }
 

--- a/src/Pages/PageUtility/VFEConversion.ts
+++ b/src/Pages/PageUtility/VFEConversion.ts
@@ -179,8 +179,6 @@ function updateHotspot<H extends Hotspot3D | Hotspot2D>(
   hotspotPath: string[],
   update: HotspotUpdate | null,
 ): H | null {
-  console.log("[VFEConversion] updateHotspot called with update:", update);
-
   // Found the hotspot that is being searched for.
   if (hotspotPath.length === 1 && hotspotPath[0] === hotspot.id) {
     if (update === null) {
@@ -199,10 +197,7 @@ function updateHotspot<H extends Hotspot3D | Hotspot2D>(
     }
     if (update.color) {
       (result as any).color = update.color;
-      console.log("[VFEConversion] Updated hotspot color:", (result as any).color);
     }
-    console.log("[VFEConversion] updated hotspot result:", result);
-
     return result;
   }
 

--- a/src/PhotosphereFeatures/PhotospherePlaceholder.tsx
+++ b/src/PhotosphereFeatures/PhotospherePlaceholder.tsx
@@ -29,7 +29,6 @@ import {
 import PopOver from "../Pages/PageUtility/PopOver";
 import { ViewerProps } from "../Pages/PhotosphereViewer";
 import { LinkArrowIconHTML } from "../UI/LinkArrowIcon";
-import PhotosphereTimelineSelect from "./PhotosphereTimelineSelect";
 import { MapPin } from "phosphor-react";
 import ReactDOMServer from "react-dom/server";
 
@@ -99,7 +98,7 @@ function convertHotspots(
         color: alpha(common.white, 0.8),
         size: 80,
       });
-    } else if (hotspot.icon?.path?.endsWith(".svg")) {
+    } else if (hotspot.icon?.path?.startsWith("blob:") || hotspot.icon?.path?.match(/\.(png|jpe?g|svg)$/)) {
       marker.image = hotspot.icon.path;
     } else { 
       marker.html = ReactDOMServer.renderToString(

--- a/src/PhotosphereFeatures/PhotospherePlaceholder.tsx
+++ b/src/PhotosphereFeatures/PhotospherePlaceholder.tsx
@@ -30,6 +30,8 @@ import PopOver from "../Pages/PageUtility/PopOver";
 import { ViewerProps } from "../Pages/PhotosphereViewer";
 import { LinkArrowIconHTML } from "../UI/LinkArrowIcon";
 import PhotosphereTimelineSelect from "./PhotosphereTimelineSelect";
+import { MapPin } from "phosphor-react";
+import ReactDOMServer from "react-dom/server";
 
 /** Convert sizes from numbers to strings ending in "px" */
 function sizeToStr(val: number): string {
@@ -97,8 +99,18 @@ function convertHotspots(
         color: alpha(common.white, 0.8),
         size: 80,
       });
-    } else {
+    } else if (hotspot.icon?.path?.endsWith(".svg")) {
       marker.image = hotspot.icon.path;
+    } else { 
+      marker.html = ReactDOMServer.renderToString(
+        <MapPin
+        size={32}
+        weight="duotone"
+        color={hotspot.color}
+        className="hotspot-icon"
+    />,
+
+      );
     }
 
     markers.push(marker);

--- a/src/PhotosphereFeatures/PhotospherePlaceholder.tsx
+++ b/src/PhotosphereFeatures/PhotospherePlaceholder.tsx
@@ -107,8 +107,6 @@ function convertHotspots(
         else if (hotspot.icon?.path === "MapTrifold") {
           IconComponent = MapTrifold;
         }
-        
-        console.log("[PhotosphereViewer] rendering hotspot with color:", hotspot.color);
 
       marker.html = ReactDOMServer.renderToString(
         <IconComponent

--- a/src/PhotosphereFeatures/PhotospherePlaceholder.tsx
+++ b/src/PhotosphereFeatures/PhotospherePlaceholder.tsx
@@ -107,6 +107,9 @@ function convertHotspots(
         else if (hotspot.icon?.path === "MapTrifold") {
           IconComponent = MapTrifold;
         }
+        
+        console.log("[PhotosphereViewer] rendering hotspot with color:", hotspot.color);
+
       marker.html = ReactDOMServer.renderToString(
         <IconComponent
           size={32}

--- a/src/PhotosphereFeatures/PhotospherePlaceholder.tsx
+++ b/src/PhotosphereFeatures/PhotospherePlaceholder.tsx
@@ -28,7 +28,7 @@ import {
 import PopOver from "../Pages/PageUtility/PopOver";
 import { ViewerProps } from "../Pages/PhotosphereViewer";
 import { LinkArrowIconHTML } from "../UI/LinkArrowIcon";
-import { MapPin } from "phosphor-react";
+import { MapPin , PushPinSimple, MapTrifold } from "phosphor-react";
 import ReactDOMServer from "react-dom/server";
 
 /** Convert sizes from numbers to strings ending in "px" */
@@ -99,15 +99,21 @@ function convertHotspots(
       });
     } else if (hotspot.icon?.path?.startsWith("blob:") || hotspot.icon?.path?.match(/\.(png|jpe?g|svg)$/)) {
       marker.image = hotspot.icon.path;
-    } else { 
+    } else {
+      let IconComponent = MapPin;
+        if (hotspot.icon?.path === "PushPinSimple") {
+          IconComponent = PushPinSimple;
+        } 
+        else if (hotspot.icon?.path === "MapTrifold") {
+          IconComponent = MapTrifold;
+        }
       marker.html = ReactDOMServer.renderToString(
-        <MapPin
-        size={32}
-        weight="duotone"
-        color={hotspot.color}
-        className="hotspot-icon"
-    />,
-
+        <IconComponent
+          size={32}
+          weight="duotone"
+          color={hotspot.color}
+          className="hotspot-icon"
+        />
       );
     }
 

--- a/src/buttons/AddHotspot.tsx
+++ b/src/buttons/AddHotspot.tsx
@@ -128,7 +128,7 @@ function ContentInput({
       return (
         <TextField
           required
-          label="URL"
+          label="URL *"
           value={content}
           onChange={(e) => {
             onUpdate(e.target.value, question, answer);
@@ -162,7 +162,7 @@ function ContentInput({
         <>
           <TextField
             required
-            label="Question"
+            label="Question *"
             value={question}
             onChange={(e) => {
               onUpdate(content, e.target.value, answer);
@@ -170,7 +170,7 @@ function ContentInput({
           />
           <TextField
             required
-            label="Answer"
+            label="Answer *"
             value={answer}
             onChange={(e) => {
               onUpdate(content, question, e.target.value);
@@ -179,7 +179,7 @@ function ContentInput({
         </>
       );
     default:
-      return <Typography>Please select a valid content type</Typography>;
+      return null; 
   }
 }
 
@@ -335,7 +335,7 @@ export function HotspotDataEditor({
   return (
     <>
       <FormControl>
-        <InputLabel id="contentType">Content Type</InputLabel>
+        <InputLabel id="contentType">Content Type*</InputLabel>
         <Select
           labelId="contentType"
           value={contentType}
@@ -461,7 +461,7 @@ function AddHotspot({
       (hotspotData.tag !== "PhotosphereLink" && iconAsset === null)
     ) {
       await alertMUI(
-        "Please provide a tooltip, a valid content type, and an icon",
+        "Please provide a tooltip, a valid content type, and a pin",
       );
       return;
     }
@@ -537,7 +537,7 @@ function AddHotspot({
       )}
 
     <FormControl fullWidth>
-      <InputLabel id="pin-type-label">Pin Type</InputLabel>
+      <InputLabel id="pin-type-label">Pin Type*</InputLabel>
       <Select
         labelId="pin-type-label"
         label="Pin Type"
@@ -557,7 +557,7 @@ function AddHotspot({
           }
         }}
       >
-        <MenuItem value="">Select Icon</MenuItem>
+        <MenuItem value="">Select Pin Type</MenuItem>
         <MenuItem value="MapPin">
           <Stack direction="row" alignItems="center" gap={1}>
             <MapPin size={20} />

--- a/src/buttons/AddHotspot.tsx
+++ b/src/buttons/AddHotspot.tsx
@@ -23,6 +23,7 @@ import {
 } from "../Pages/PageUtility/DataStructures.ts";
 import PhotosphereSelector from "../PhotosphereFeatures/PhotosphereSelector.tsx";
 import { alertMUI } from "../UI/StyledDialogWrapper.tsx";
+import { MapPin, PushPinSimple, MapTrifold } from "phosphor-react";
 
 // from https://github.com/Alcumus/react-doc-viewer?tab=readme-ov-file#current-renderable-file-types
 const documentAcceptTypes = [
@@ -449,6 +450,9 @@ function AddHotspot({
   const [level, setLevel] = useState(0); // State for level
   const [iconAsset, setIconAsset] = useState<Asset | null>(defaultIcon());
   const [color, setColor] = useState("#1976d2"); 
+  const [isCustomIcon, setIsCustomIcon] = useState(false);
+  const [customIconFile, setCustomIconFile] = useState<File | null>(null);
+
 
   async function handleAddHotspot() {
     if (
@@ -475,7 +479,7 @@ function AddHotspot({
       level,
       icon: iconAsset ?? defaultIcon(), // store default icon for photosphere links
       data: hotspotData,
-      color,
+      color: isCustomIcon ? undefined : color,
     };
 
     onAddHotspot(newHotspot);
@@ -520,14 +524,6 @@ function AddHotspot({
           defaultValue={String(direction.toFixed(2))}
           sx={{ flexGrow: 1 }}
         />
-        <TextField
-          type="color"
-          label="Pin Color"
-          value={color}
-          onChange={(e) => setColor(e.target.value)}
-          sx={{ width: "150px" }}
-          InputLabelProps={{ shrink: true }}
-        />
       </Stack>
 
       {hotspotData?.tag !== "PhotosphereLink" && (
@@ -540,15 +536,86 @@ function AddHotspot({
         />
       )}
 
+    <FormControl fullWidth>
+      <InputLabel id="pin-type-label">Pin Type</InputLabel>
+      <Select
+        labelId="pin-type-label"
+        label="Pin Type"
+        value={isCustomIcon ? "custom" : iconAsset?.path || ""}
+        onChange={(e) => {
+          const value = e.target.value;
+          if (value === "custom") {
+            setIsCustomIcon(true);
+            setIconAsset(null);
+          } else {
+            setIsCustomIcon(false);
+            setIconAsset({
+              tag: "Runtime",
+              id: newID(),
+              path: value,
+            });
+          }
+        }}
+      >
+        <MenuItem value="">Select Icon</MenuItem>
+        <MenuItem value="MapPin">
+          <Stack direction="row" alignItems="center" gap={1}>
+            <MapPin size={20} />
+            Map Pin
+          </Stack>
+        </MenuItem>
+        <MenuItem value="PushPinSimple">
+          <Stack direction="row" alignItems="center" gap={1}>
+            <PushPinSimple size={20} />
+            Push Pin Simple
+          </Stack>
+        </MenuItem>
+        <MenuItem value="MapTrifold">
+          <Stack direction="row" alignItems="center" gap={1}>
+            <MapTrifold size={20} />
+            Map Trifold
+          </Stack>
+        </MenuItem>
+        <MenuItem value="custom">Custom Icon</MenuItem>
+      </Select>
+    </FormControl>
+
+          {/* Only show color picker for built-in icons */}
+          {!isCustomIcon && (
+            <TextField
+              label="Pin Color"
+              type="color"
+              value={color}
+              onChange={(e) => setColor(e.target.value)}
+              InputLabelProps={{ shrink: true }}
+              fullWidth
+            />
+          )}
+
+          {/* Only show file input for custom icon */}
+          {isCustomIcon && (
+            <MuiFileInput
+              label="Upload Custom Icon*"
+              value={customIconFile}
+              onChange={(file) => {
+                setCustomIconFile(file);
+                if (file) {
+                  setIconAsset({
+                    tag: "Runtime",
+                    id: newID(),
+                    path: URL.createObjectURL(file),
+                  });
+                }
+              }}
+              inputProps={{ accept: "image/*" }}
+              fullWidth
+            />
+          )}
       <HotspotDataEditor
         hotspotData={hotspotData}
         setHotspotData={setHotspotData}
         photosphereOptions={photosphereOptions}
       />
-
-      {hotspotData?.tag !== "PhotosphereLink" && (
-        <HotspotIconEditor iconAsset={iconAsset} setIconAsset={setIconAsset} />
-      )}
 
       <TextField
         label="Level"

--- a/src/buttons/AddHotspot.tsx
+++ b/src/buttons/AddHotspot.tsx
@@ -448,6 +448,7 @@ function AddHotspot({
   const [hotspotData, setHotspotData] = useState<HotspotData | null>(null);
   const [level, setLevel] = useState(0); // State for level
   const [iconAsset, setIconAsset] = useState<Asset | null>(defaultIcon());
+  const [color, setColor] = useState("#1976d2"); 
 
   async function handleAddHotspot() {
     if (
@@ -474,6 +475,7 @@ function AddHotspot({
       level,
       icon: iconAsset ?? defaultIcon(), // store default icon for photosphere links
       data: hotspotData,
+      color,
     };
 
     onAddHotspot(newHotspot);
@@ -517,6 +519,14 @@ function AddHotspot({
           }}
           defaultValue={String(direction.toFixed(2))}
           sx={{ flexGrow: 1 }}
+        />
+        <TextField
+          type="color"
+          label="Pin Color"
+          value={color}
+          onChange={(e) => setColor(e.target.value)}
+          sx={{ width: "150px" }}
+          InputLabelProps={{ shrink: true }}
         />
       </Stack>
 

--- a/src/index.css
+++ b/src/index.css
@@ -17,3 +17,17 @@ body {
 .react-colorful__hue {
   border-radius: 0 0 4px 4px !important;
 }
+
+.hotspot-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.2s ease, filter 0.2s ease;
+  filter: brightness(0.9);
+}
+
+.hotspot-icon:hover {
+  transform: scale(1.15);
+  filter: brightness(1.5) drop-shadow(0 0 6px #1976d2);
+  cursor: pointer;
+}


### PR DESCRIPTION
This PR introduces changes that allow for selection of pin type and color at creation only. The editing of the pin type and color is temporarily disabled in the hotspot editor to avoid bugs. 

Tested by creating new hotspots with the less obtrusive icons for varying icons and colors. 

This is a work in progress and the editing of the pin type and color will be added if time allows 