### PR TITLE
Fix for the old hotspot bug

### DIFF
--- a/src/Pages/PhotosphereEditor.tsx
+++ b/src/Pages/PhotosphereEditor.tsx
@@ -145,7 +145,7 @@ function PhotosphereEditor({
         }
       }
     }
-    sessionStorage.setItem("listEditedHotspot", JSON.stringify(hotspotList));
+    sessionStorage.setItem("listEditedHotspot", JSON.stringify(hotspotPath));
 
     onUpdateVFE(updatedVFE);
     setUpdateTrigger((prev) => prev + 1);

--- a/src/PhotosphereFeatures/PhotospherePlaceholder.tsx
+++ b/src/PhotosphereFeatures/PhotospherePlaceholder.tsx
@@ -306,9 +306,18 @@ function PhotospherePlaceholder({
       // clear popovers on scene change
       // Upon saving a hotspot, the scene will refresh and automatically load back into what ever hotspot was saved last
       if (Number(sessionStorage.getItem("lastEditedHotspotFlag")) == 1) {
-        setHotspotArray(
-          JSON.parse(sessionStorage.getItem("listEditedHotspot") || "[]"),
-        );
+        if (JSON.parse(sessionStorage.getItem("listEditedHotspot") || "[]").length > 0) {
+          let hotspotItem: (Hotspot2D | Hotspot3D) = vfe.photospheres[currentPS].hotspots[ JSON.parse(sessionStorage.getItem("listEditedHotspot") || "[]")[0] ];
+          let hotspotList: (Hotspot2D | Hotspot3D)[] = [ hotspotItem ];
+
+          for (let i = 1; i < JSON.parse(sessionStorage.getItem("listEditedHotspot") || "[]").length; ++i) {
+            if ('hotspots' in hotspotItem.data) {
+                hotspotItem = hotspotItem.data.hotspots[ JSON.parse(sessionStorage.getItem("listEditedHotspot") || "[]")[i] ];
+              hotspotList.push(hotspotItem);
+            }
+          }
+          setHotspotArray(hotspotList);
+        }
       } else {
         setHotspotArray([]);
       }


### PR DESCRIPTION
I changed it so that after reloading, the application searches for and displays the new hotspot under the same ID instead of loading the old hotspot object saved before reloading.