### PR TITLE
Made drop down display more clearly

### DIFF
--- a/src/Pages/PhotosphereViewer.tsx
+++ b/src/Pages/PhotosphereViewer.tsx
@@ -238,7 +238,7 @@ function PhotosphereViewer({
           >
             <ExpandMore
               expand={showSplitViewFeatures}
-              title="Show Split View Features"
+              tooltip="Show Split View Features"
               onClick={() => {
                 const willExpand = !showSplitViewFeatures;
                 setShowSplitViewFeatures(willExpand);
@@ -248,7 +248,14 @@ function PhotosphereViewer({
                   setRunExpandTutorial(true);
                 }
               }}
-            ></ExpandMore>
+            >
+              <Typography
+                variant="body2"
+                sx={{ color: "black", fontSize: "14px" }}
+              >
+                Split View Features ?{" "}
+              </Typography>
+            </ExpandMore>
             <Box sx={{ padding: "0 5px" }}>
               <PhotosphereSelector
                 size="small"

--- a/src/Pages/PhotosphereViewer.tsx
+++ b/src/Pages/PhotosphereViewer.tsx
@@ -249,12 +249,19 @@ function PhotosphereViewer({
                 }
               }}
             >
-              <Typography
-                variant="body2"
-                sx={{ color: "black", fontSize: "14px" }}
+              <Button
+                variant="contained"
+                color="primary"
+                size="small"
+                sx={{
+                  fontSize: "14px",
+                  textTransform: "none",
+                  borderRadius: "8px",
+                  boxShadow: 1,
+                }}
               >
-                Split View Features ?{" "}
-              </Typography>
+                Split View Features{" "}
+              </Button>
             </ExpandMore>
             <Box sx={{ padding: "0 5px" }}>
               <PhotosphereSelector

--- a/src/UI/ExpandMore.tsx
+++ b/src/UI/ExpandMore.tsx
@@ -3,15 +3,15 @@ import { IconButton, IconButtonProps, Tooltip, styled } from "@mui/material";
 
 interface ExpandMoreProps extends IconButtonProps {
   expand: boolean;
-  title: string;
+  tooltip: string;
 }
 
 export const ExpandMore = styled(
-  ({ expand, title, ...other }: ExpandMoreProps) => {
+  ({ expand, tooltip, children, ...other }: ExpandMoreProps) => {
     return (
-      <Tooltip title={title}>
+      <Tooltip title={tooltip}>
         <IconButton {...other}>
-          <ExpandMoreIcon />
+          {expand ? <ExpandMoreIcon /> : children}
         </IconButton>
       </Tooltip>
     );


### PR DESCRIPTION
Updated the drop down icon for the split view feature to display its intention more clearly. Very quick change just UI fix. 
Tested by playing around the application and seems to work without effecting anything.