### PR TITLE
Ws-85 save function and split view safeguards (Ws-84)

### DIFF
--- a/src/Pages/PhotosphereEditor.tsx
+++ b/src/Pages/PhotosphereEditor.tsx
@@ -120,38 +120,26 @@ function PhotosphereEditor({
       if (!confirmed) return;
     }
 
-    const updatedPhotosphere = updatePhotosphereHotspot(
-      vfe.photospheres[currentPS],
-      hotspotPath,
-      update,
-    );
+    if (hotspotPath.length > 0 && sessionStorage.getItem("EditedHotspotPhotoSphere") != null) {
+      const updatedPhotosphere = updatePhotosphereHotspot(
+        vfe.photospheres[sessionStorage.getItem("EditedHotspotPhotoSphere")],
+        hotspotPath,
+        update,
+      );
 
-    const updatedVFE = {
-      ...vfe,
-      photospheres: {
-        ...vfe.photospheres,
-        [currentPS]: updatedPhotosphere,
-      },
-    };
+      const updatedVFE = {
+        ...vfe,
+        photospheres: {
+          ...vfe.photospheres,
+          [sessionStorage.getItem("EditedHotspotPhotoSphere") || currentPS]: updatedPhotosphere,
+        },
+      };
 
-    const hotspotList: (Hotspot2D | Hotspot3D)[] = [
-      vfe.photospheres[currentPS].hotspots[hotspotPath[0]],
-    ];
-    if (hotspotPath.length > 1) {
-      let hotspotItem: Hotspot2D | Hotspot3D =
-        vfe.photospheres[currentPS].hotspots[hotspotPath[0]];
+      sessionStorage.setItem("listEditedHotspot", JSON.stringify(hotspotPath));
 
-      for (let i = 1; i < hotspotPath.length; ++i) {
-        if ("hotspots" in hotspotItem.data) {
-          hotspotItem = hotspotItem.data.hotspots[hotspotPath[i]];
-          hotspotList.push(hotspotItem);
-        }
-      }
+      onUpdateVFE(updatedVFE);
+      setUpdateTrigger((prev) => prev + 1);
     }
-    sessionStorage.setItem("listEditedHotspot", JSON.stringify(hotspotPath));
-
-    onUpdateVFE(updatedVFE);
-    setUpdateTrigger((prev) => prev + 1);
   }
 
   async function handleRemovePhotosphere(photosphereId: string) {

--- a/src/Pages/PhotosphereEditor.tsx
+++ b/src/Pages/PhotosphereEditor.tsx
@@ -18,7 +18,6 @@ import ChangePhotosphere from "../buttons/ChangePhotosphere.tsx";
 import EditNavMap from "../buttons/EditNavMap.tsx";
 import RemovePhotosphere from "../buttons/RemovePhotosphere.tsx";
 import {
-  Hotspot2D,
   Hotspot3D,
   NavMap,
   Photosphere,
@@ -122,7 +121,7 @@ function PhotosphereEditor({
 
     if (hotspotPath.length > 0 && sessionStorage.getItem("EditedHotspotPhotoSphere") != null) {
       const updatedPhotosphere = updatePhotosphereHotspot(
-        vfe.photospheres[sessionStorage.getItem("EditedHotspotPhotoSphere")],
+          vfe.photospheres[sessionStorage.getItem("EditedHotspotPhotoSphere") || currentPS],
         hotspotPath,
         update,
       );
@@ -137,6 +136,7 @@ function PhotosphereEditor({
 
       sessionStorage.setItem("listEditedHotspot", JSON.stringify(hotspotPath));
 
+      onChangePS(sessionStorage.getItem("EditedHotspotPhotoSphere") || currentPS);
       onUpdateVFE(updatedVFE);
       setUpdateTrigger((prev) => prev + 1);
     }

--- a/src/Pages/PhotosphereViewer.tsx
+++ b/src/Pages/PhotosphereViewer.tsx
@@ -304,6 +304,7 @@ function PhotosphereViewer({
                   variant={isSplitView ? "contained" : "outlined"}
                   onClick={() => {
                     setIsSplitView(!isSplitView);
+                    onChangePS(primaryPhotosphere.id);
                   }}
                 >
                   <Typography sx={{ fontSize: "14px" }}>Split View</Typography>

--- a/src/PhotosphereFeatures/PhotospherePlaceholder.tsx
+++ b/src/PhotosphereFeatures/PhotospherePlaceholder.tsx
@@ -280,6 +280,10 @@ function PhotospherePlaceholder({
         if (!isHotspotVisited && !isEditor) {
           void addPoints(10);
         }
+
+        // Incase the photosphere changes after saving, this is so the program doesn't try to get a hotspot from the wrong photosphere
+        sessionStorage.setItem("EditedHotspotPhotoSphere", currentState.id);
+        
         const passMarker = currentState.hotspots[marker.config.id];
         setHotspotArray([passMarker]);
         handleVisit(currentState.id, marker.config.id);
@@ -334,8 +338,10 @@ function PhotospherePlaceholder({
       // clear popovers on scene change
       // Upon saving a hotspot, the scene will refresh and automatically load back into what ever hotspot was saved last
       if (Number(sessionStorage.getItem("lastEditedHotspotFlag")) == 1) {
-        if (JSON.parse(sessionStorage.getItem("listEditedHotspot") || "[]").length > 0) {
-          let hotspotItem: (Hotspot2D | Hotspot3D) = vfe.photospheres[currentPS].hotspots[ JSON.parse(sessionStorage.getItem("listEditedHotspot") || "[]")[0] ];
+        let photosphereItem = (sessionStorage.getItem("EditedHotspotPhotoSphere") || "");
+
+        if (JSON.parse(sessionStorage.getItem("listEditedHotspot") || "[]").length > 0 && photosphereItem != "") {
+          let hotspotItem: (Hotspot2D | Hotspot3D) = vfe.photospheres[photosphereItem].hotspots[ JSON.parse(sessionStorage.getItem("listEditedHotspot") || "[]")[0] ];
           let hotspotList: (Hotspot2D | Hotspot3D)[] = [ hotspotItem ];
 
           for (let i = 1; i < JSON.parse(sessionStorage.getItem("listEditedHotspot") || "[]").length; ++i) {


### PR DESCRIPTION
Add more safeguard conditionals to prevent referencing variables that don't exist. Also added the ability to save hotspots even if they're menu is open in a different photosphere. This was accomplished by setting the current photosphere to the one that holds the previously saved hotspot. Also adding Braulio's change so that the current photosphere changes back to the main one after split view is disabled.