### PR TITLE
Fix for prototype VFE to show on app start

### DIFF
--- a/src/Pages/App.tsx
+++ b/src/Pages/App.tsx
@@ -4,6 +4,7 @@ import { Route, Routes, useNavigate } from "react-router-dom";
 import CreateVFEForm from "../Pages/CreateVFE.tsx";
 import LandingPage from "../Pages/LandingPage.tsx";
 import Prototype from "../Prototype/Prototype.tsx";
+import prototypeVFE from "../Prototype/data.json";
 import { VFE } from "./PageUtility/DataStructures.ts";
 import { load } from "./PageUtility/FileOperations.ts";
 import {
@@ -13,14 +14,29 @@ import {
 import VFELoader from "./PageUtility/VFELoader.tsx";
 import PhotosphereEditor from "./PhotosphereEditor.tsx";
 import PhotosphereViewer from "./PhotosphereViewer.tsx";
+import { useEffect, useState } from "react";
 
 // Main component acts as a main entry point for the application
 // Should decide what we are doing, going to LandingPage/Rendering VFE
 function AppRoot() {
   const navigate = useNavigate();
+  const [reloadVFEList, setReloadVFEList] = useState(0);
+
+  useEffect(() => {
+    async function preloadPrototype() {
+      const exists = await localforage.getItem(prototypeVFE.name);
+      if (!exists) {
+        await localforage.setItem(prototypeVFE.name, prototypeVFE as VFE);
+        setReloadVFEList(prev => prev + 1);
+      }
+    }
+  
+    void preloadPrototype();
+  }, []);
 
   //Create a function to set useState true
   function handleLoadTestVFE() {
+    setReloadVFEList((prev) => prev + 1);
     navigate("/prototype");
   }
 
@@ -57,6 +73,7 @@ function AppRoot() {
             onLoadVFE={(file, openInViewer) => {
               void handleLoadVFE(file, openInViewer);
             }}
+            reloadTrigger={reloadVFEList}
           />
         }
       />

--- a/src/Pages/LandingPage.tsx
+++ b/src/Pages/LandingPage.tsx
@@ -19,12 +19,14 @@ interface LandingPageProps {
   onLoadTestVFE: () => void;
   onCreateVFE: () => void;
   onLoadVFE: (file: File, openInViewer: boolean) => void;
+  reloadTrigger: number;
 }
 
 function LandingPage({
   onLoadTestVFE,
   onCreateVFE,
   onLoadVFE,
+  reloadTrigger,
 }: LandingPageProps) {
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [openDialog, setOpenDialog] = useState(false);
@@ -90,6 +92,7 @@ function LandingPage({
         />
         <VFEList 
           className="vfe-list-area"
+          reloadTrigger={reloadTrigger}
         />
       </Stack>
 

--- a/src/Pages/PageUtility/VFEList.tsx
+++ b/src/Pages/PageUtility/VFEList.tsx
@@ -23,9 +23,10 @@ import { convertStoredToRuntime } from "./VFEConversion";
 type NavMapRecord = Partial<Record<string, string>>;
 interface VFEListProps {
   className?: string;
+  reloadTrigger?: number;
 }
 
-function VFEList({ className }: VFEListProps) {
+function VFEList({ className, reloadTrigger}: VFEListProps) {
   const [names, setNames] = useState<string[]>([]);
   const [navMaps, setNavMaps] = useState<NavMapRecord>({});
 
@@ -48,7 +49,7 @@ function VFEList({ className }: VFEListProps) {
     }
 
     void load();
-  }, []);
+  }, [reloadTrigger]); 
 
   async function deleteVFE(toDelete: string) {
     const confirmed = await confirmMUI(`Delete ${toDelete}?`, {


### PR DESCRIPTION
**Issue**
Previously, the ElkIslandPrototype only appeared in the VFE list after the user manually clicked the Demo button. This made it impossible to explore the Edit features until a reload happened. 

**Fix**
Preloaded the prototype from data.json directly within App.tsx
Added reloadTrigger to force reload, allowing the ElkIsland prototype to show up immediately. 

**Testing**
Tested this change by opening in incognito mode on Chrome and Safari to ensure the prototype is preloaded

**Result**
The ElkIslandPrototype is now visible upon app start