### PR TITLE
Implemented the save feature Rick suggested with the "Choose Hotspot Location" menu

### DIFF
--- a/src/Pages/HotspotEditor.tsx
+++ b/src/Pages/HotspotEditor.tsx
@@ -545,21 +545,25 @@ function HotspotEditor({
               image={previewData.src.path}
               hotspot={locationHotspot}
               onSave={(updatedHotspot) => {
-                updateNestedHotspot(updatedHotspot);
                 if (
+                  previewData?.tag === "Image" &&
                   updatedHotspot != null && 
                   'id' in updatedHotspot &&
                   previewData != null &&
                   'hotspots' in previewData
                 ) {
+                  
                   if (updatedHotspot.id in previewData.hotspots) {
                     previewData.hotspots[updatedHotspot.id].x = updatedHotspot.x
                     previewData.hotspots[updatedHotspot.id].y = updatedHotspot.y
                   }
+                  else {
+                    previewData.hotspots = { ...previewData.hotspots, [updatedHotspot.id]: updatedHotspot }
+                  }
 
-                  sessionStorage.setItem("lastEditedHotspotFlag", "1"); // Set to return to hotspot menu after pge refresh
-                  setEdited(false); // Reset edited state after saving
-
+                  sessionStorage.setItem("lastEditedHotspotFlag", "1");  // Set to return to hotspot menu after pge refresh
+                  setEdited(false);  // Reset edited state after saving
+                  
                   updateHotspot(
                     previewTooltip,
                     previewData,

--- a/src/Pages/HotspotEditor.tsx
+++ b/src/Pages/HotspotEditor.tsx
@@ -546,6 +546,27 @@ function HotspotEditor({
               hotspot={locationHotspot}
               onSave={(updatedHotspot) => {
                 updateNestedHotspot(updatedHotspot);
+                if (
+                  updatedHotspot != null && 
+                  'id' in updatedHotspot &&
+                  previewData != null &&
+                  'hotspots' in previewData
+                ) {
+                  if (updatedHotspot.id in previewData.hotspots) {
+                    previewData.hotspots[updatedHotspot.id].x = updatedHotspot.x
+                    previewData.hotspots[updatedHotspot.id].y = updatedHotspot.y
+                  }
+
+                  sessionStorage.setItem("lastEditedHotspotFlag", "1"); // Set to return to hotspot menu after pge refresh
+                  setEdited(false); // Reset edited state after saving
+
+                  updateHotspot(
+                    previewTooltip,
+                    previewData,
+                    previewIcon ?? undefined,
+                    previewColor
+                  );
+                }
               }}
               onClose={() => {
                 setLocationHotspot(null);

--- a/src/Pages/HotspotEditor.tsx
+++ b/src/Pages/HotspotEditor.tsx
@@ -561,7 +561,7 @@ function HotspotEditor({
                     previewData.hotspots = { ...previewData.hotspots, [updatedHotspot.id]: updatedHotspot }
                   }
 
-                  sessionStorage.setItem("lastEditedHotspotFlag", "1");  // Set to return to hotspot menu after pge refresh
+                  sessionStorage.setItem("lastEditedHotspotFlag", "1");  // Set to return to hotspot menu after page refresh
                   setEdited(false);  // Reset edited state after saving
                   
                   updateHotspot(


### PR DESCRIPTION
Made it so that when the user clicks the save button on the "Choose Hotspot Location" menu, it will automatically save the location and refresh the page to show the change. This is so the user doesn't have to click the save button again in the main hotspot editing menu. This will also bring the user back to the previously edited hotspot. This works when moving an existing nested hotspot or creating a new one.

To Test:
When either making a new nested hotspot or moving an existing one, the save button should refresh with a new nested hotspot location saved, and automatically bring back the hotspot editing menu (same functionality as normal save button). Edit button should also not be grayed out after moving nested hotspot.
![image](https://github.com/user-attachments/assets/e5406095-259f-4d5c-adc1-3fbeea09de2f)