### PR TITLE
Fixed the save functionality so the photosphere value defaults to the currentPS

### DIFF
--- a/src/Pages/PhotosphereEditor.tsx
+++ b/src/Pages/PhotosphereEditor.tsx
@@ -138,7 +138,7 @@ function PhotosphereEditor({
       if (!confirmed) return;
     }
 
-    if (hotspotPath.length > 0 && sessionStorage.getItem("EditedHotspotPhotoSphere") != null) {
+    if (hotspotPath.length > 0) {
       const updatedPhotosphere = updatePhotosphereHotspot(
           vfe.photospheres[sessionStorage.getItem("EditedHotspotPhotoSphere") || currentPS],
         hotspotPath,
@@ -252,8 +252,6 @@ function PhotosphereEditor({
       [date ? date.format("YYYY-DD-MM") : dayjs().format("YYYY-DD-MM")]:
         newPhotosphere.id,
     };
-
-    console.log(updatedVFE.photospheres[currentPS]);
 
     onUpdateVFE(updatedVFE);
     onChangePS(newPhotosphere.id);

--- a/src/PhotosphereFeatures/PhotospherePlaceholder.tsx
+++ b/src/PhotosphereFeatures/PhotospherePlaceholder.tsx
@@ -282,7 +282,7 @@ function PhotospherePlaceholder({
           void addPoints(10);
         }
 
-        // Incase the photosphere changes after saving, this is so the program doesn't try to get a hotspot from the wrong photosphere
+        // When the photosphere is in split view, this is so the program doesn't try to get a hotspot from the wrong photosphere after saving
         sessionStorage.setItem("EditedHotspotPhotoSphere", currentState.id);
         
         const passMarker = currentState.hotspots[marker.config.id];
@@ -339,18 +339,15 @@ function PhotospherePlaceholder({
       // clear popovers on scene change
       // Upon saving a hotspot, the scene will refresh and automatically load back into what ever hotspot was saved last
       if (Number(sessionStorage.getItem("lastEditedHotspotFlag")) == 1) {
-        let photosphereItem = (sessionStorage.getItem("EditedHotspotPhotoSphere") || "");
-
-        if (
-          JSON.parse(sessionStorage.getItem("listEditedHotspot") || "[]")
-            .length > 0 && photosphereItem != ""
-        ) {
+        let photosphereItem = (sessionStorage.getItem("EditedHotspotPhotoSphere") || "") || currentPS;
+        
+        if ( JSON.parse(sessionStorage.getItem("listEditedHotspot") || "[]").length > 0 ) {
           let hotspotItem: Hotspot2D | Hotspot3D =
             vfe.photospheres[photosphereItem].hotspots[
               JSON.parse(sessionStorage.getItem("listEditedHotspot") || "[]")[0]
             ];
           let hotspotList: (Hotspot2D | Hotspot3D)[] = [hotspotItem];
-
+          
           for (
             let i = 1;
             i <
@@ -378,8 +375,10 @@ function PhotospherePlaceholder({
         setHotspotArray([]);
       }
 
-      sessionStorage.setItem("listEditedHotspot", "[]"); // Clear the last hotspot so it doesn't keep loading into the same hotspot
+      // Clear these items so they don't affect the hotspot auto-loader
+      sessionStorage.setItem("listEditedHotspot", "[]"); 
       sessionStorage.removeItem("lastEditedHotspotFlag");
+      sessionStorage.removeItem("EditedHotspotPhotoSphere");
     });
     if (isPrimary) {
       const map = instance.getPlugin<MapPlugin>(MapPlugin);
@@ -409,6 +408,7 @@ function PhotospherePlaceholder({
           }}
           closeAll={() => {
             setHotspotArray([]);
+            sessionStorage.removeItem("EditedHotspotPhotoSphere");
           }}
           onUpdateHotspot={onUpdateHotspot}
           changeScene={(id) => {


### PR DESCRIPTION
Fixed some parts of the code that didn't allow a save if EditedHotspotPhotoSphere wasn't set properly. This value shouldn't be the default, as it's only needed for split view. currentPS should be the default and has been changed accordingly. 

To Test:
- Open the VFE in editor mode > Activate split view > Change the 2nd split view to a different photosphere > Regardless of which side is chosen, a hotspot from either side should save properly.

- Open the VFE in editor mode > Click the side bar menu > Open a hotspot from either CHILD_South_1 or CHILD_South_2 from the side bar menu > Edit and save the hotspot, and make sure the hotspot saves properly. This bypasses the EditedHotspotPhotoSphere value but should be alright as it falls back on currentPS.

**NOTE: Don't choose a nested hotspot from a different photosphere in the sidebar. The currentPS value doesn't get set when selecting from this menu, and it either doesn't save when "Save and Exit" is clicked or crashes when "Save" is clicked.