### PR TITLE
Allow lower-level hotspot position adjustments in hotspot editor

### DIFF
--- a/src/Pages/HotspotEditor.tsx
+++ b/src/Pages/HotspotEditor.tsx
@@ -678,6 +678,8 @@ function HotspotEditor({
 
             {!hotspotsCollapsed &&
               nestedHotspotLength > 0 &&
+              previewData &&
+              'hotspots' in previewData && 
               Object.values(previewData.hotspots).map((hotspot2D) => (
                 <HotspotCard
                   key={hotspot2D.id}

--- a/src/Pages/PageUtility/PopOver.tsx
+++ b/src/Pages/PageUtility/PopOver.tsx
@@ -284,6 +284,10 @@ function PopOver({
     onUpdateHotspot?.(hotspotPath, { tooltip, data, icon, color});
   }
 
+  function updatePrevHotspot(tooltip: string, data: HotspotData, icon?: Asset, color?: string) {
+      onUpdateHotspot?.(hotspotPath.slice(0, -1), { tooltip, data, icon, color});
+  }
+
   function openNestedHotspot(hotspot2D: Hotspot2D) {
     if (edited) {
       setSnackbarMessage(
@@ -376,6 +380,7 @@ function PopOver({
               <HotspotEditor
                 edited={edited}
                 setEdited={setEdited}
+                hotspotPath={hotspotPath}
                 previewTooltip={previewTooltip}
                 setPreviewTooltip={setPreviewTooltip}
                 previewData={previewData}
@@ -385,6 +390,7 @@ function PopOver({
                 resetHotspot={resetHotspot}
                 deleteHotspot={deleteHotspot}
                 updateHotspot={updateHotspot}
+                updatePrevHotspot={updatePrevHotspot}
                 openNestedHotspot={openNestedHotspot}
                 photosphereOptions={availablePhotosphereOptions} // Pass down the new props
                 previewColor={previewColor}

--- a/src/PhotosphereFeatures/PhotospherePlaceholder.tsx
+++ b/src/PhotosphereFeatures/PhotospherePlaceholder.tsx
@@ -375,10 +375,9 @@ function PhotospherePlaceholder({
         setHotspotArray([]);
       }
 
-      // Clear these items so they don't affect the hotspot auto-loader
+      // Clear these items so they don't affect the hotspot editing menu
       sessionStorage.setItem("listEditedHotspot", "[]"); 
       sessionStorage.removeItem("lastEditedHotspotFlag");
-      sessionStorage.removeItem("EditedHotspotPhotoSphere");
     });
     if (isPrimary) {
       const map = instance.getPlugin<MapPlugin>(MapPlugin);


### PR DESCRIPTION
Took way longer than expected. Got this feature working and should be the last one to be added. 

This can be tested when navigating to a nested hotspot and clicking the "Pin Location" button. This will open the nested hotspot's location in the parent hotspot and allow the user to edit it from the nested menu.