### PR TITLE
Showing potential fixes to Rick's comments

### DIFF
--- a/src/Pages/PhotosphereViewer.tsx
+++ b/src/Pages/PhotosphereViewer.tsx
@@ -266,7 +266,9 @@ function PhotosphereViewer({
             <Box sx={{ padding: "0 5px" }}>
               <PhotosphereSelector
                 size="small"
-                options={Object.keys(vfe.photospheres)}
+                options={Object.keys(vfe.photospheres).filter(
+                  (ps) => !vfe.photospheres[ps].parentPS,
+                )}
                 value={
                   primaryPhotosphere.parentPS
                     ? primaryPhotosphere.parentPS

--- a/src/Pages/PhotosphereViewer.tsx
+++ b/src/Pages/PhotosphereViewer.tsx
@@ -361,6 +361,7 @@ function PhotosphereViewer({
                 <PhotosphereTimelineSelect
                   onSelect={(ps: string) => {
                     setPrimaryPhotosphere(vfe.photospheres[ps]);
+                    onChangePS(ps);
                   }}
                 />
               </Stack>
@@ -425,6 +426,7 @@ function PhotosphereViewer({
                     <PhotosphereTimelineSelect
                       onSelect={(ps: string) => {
                         setSplitPhotosphere(vfe.photospheres[ps]);
+                        onChangePS(ps);
                       }}
                     />
                   </Stack>

--- a/src/PhotosphereFeatures/PhotosphereTimelineSelect.tsx
+++ b/src/PhotosphereFeatures/PhotosphereTimelineSelect.tsx
@@ -31,7 +31,8 @@ function PhotosphereTimelineSelect({
     } else if (wasTimelineSelected) {
       // make sure not to change both scenes when
       // going back to parent PS
-      onSelect(currentSelected);
+      //onSelect(currentSelected);
+      // temporarily disable to test fix for other bug
     }
   }, [currentPS]);
 


### PR DESCRIPTION
First commit is showing the tradeoff of bugs. It allows the viewer to not worry about which scene the features will be added to when editing a scene. However, if you switch to split view and view two scenes, if one of them switches to the "Now" it will force both of them to that scene. 

Second commit just addresses the scene selector showing child scenes. I thought this was fixed earlier but i moved it back. Shouldn't break anything. 


I recommend testing thoroughly and deciding what direction is better for the team.