### PR TITLE
WS-92-Sidebar-Debugging-Nested-Hotspot-Save

### DIFF
--- a/src/PhotosphereFeatures/PhotosphereHotspotSidebar.tsx
+++ b/src/PhotosphereFeatures/PhotosphereHotspotSidebar.tsx
@@ -72,9 +72,12 @@ function PhotosphereHotspotSideBar({
     currentPS === photosphere ? null : setValue(photosphere);
   }
 
-  function handleHSListClick(hotspot: Hotspot3D, photosphereId: string) {
+  function handleHSListClick(
+    hotspot: (Hotspot3D | Hotspot2D)[],
+    photosphereId: string,
+  ) {
     if (currentPS !== photosphereId) setValue(photosphereId);
-    setHotspotArray([hotspot]);
+    setHotspotArray(hotspot);
     centerHotspot(hotspotArray);
   }
 
@@ -245,9 +248,7 @@ function PhotosphereHotspotSideBar({
         >
           <ListItemButton
             onClick={() => {
-              handleHSListClick(hotspot, photosphere.id);
-              setHotspotArray([...path, hotspot]);
-              centerHotspot([...path, hotspot]);
+              handleHSListClick([...path, hotspot], photosphere.id);
             }}
             sx={{ backgroundColor: getBackgroundColor(depth) }}
           >
@@ -329,9 +330,7 @@ function PhotosphereHotspotSideBar({
         >
           <ListItemButton
             onClick={() => {
-              handleHSListClick(hotspot, photosphere.id);
-              setHotspotArray([...path, hotspot]);
-              centerHotspot([...path, hotspot]);
+              handleHSListClick([...path, hotspot], photosphere.id);
             }}
             sx={{ backgroundColor: getBackgroundColor(depth) }}
           >
@@ -424,8 +423,7 @@ function PhotosphereHotspotSideBar({
         >
           <ListItemButton
             onClick={() => {
-              setHotspotArray([...path, hotspot]);
-              centerHotspot([...path, hotspot]);
+              handleHSListClick([...path, hotspot], photosphere.id);
             }}
             sx={{ backgroundColor: getBackgroundColor(depth) }}
           >
@@ -507,8 +505,7 @@ function PhotosphereHotspotSideBar({
         >
           <ListItemButton
             onClick={() => {
-              setHotspotArray([...path, hotspot]);
-              centerHotspot([...path, hotspot]);
+              handleHSListClick([...path, hotspot], photosphere.id);
             }}
             sx={{ backgroundColor: getBackgroundColor(depth) }}
           >


### PR DESCRIPTION
Bug Description:
"Nested hotspots and Sidebar
Open a vfe (with two photosphere and at least one having nested hotspot) in editing mode > Open the photosphere that doesn't have the nested hotspot > Open the side bar > Expand the photospheres to show the nested hotspot in the different photosphere > Click the nested hotspot to open the editing menu > If Save and Exit is clicked, any changes made to the hotspot won't remain after the page refreshes. If Save is clicked, the program will crash since the program tries to find a hotspot in the incorrect photosphere.

I think the main problem is that currentPS doesn't get set when a nested hotspot is opened even though it gets set when the hotspot directly on the photosphere is chosen" - Carl

Solution has been implemented. Ran test of case described above and passed.